### PR TITLE
Add packer to ci-aws. Useful to build AMIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM codacy/ci-base:2018.08.3
 
-LABEL maintainer="Daniel Reigada (dreigada) <daniel@codacy.com>"
+LABEL maintainer="Codacy <team@codacy.com>"
+
+ENV PACKER_VERSION=1.3.2
+ENV PACKER_SHA256SUM=5e51808299135fee7a2e664b09f401b5712b5ef18bd4bad5bc50f4dcd8b149a1
 
 COPY requirements.pip .
 
@@ -10,3 +13,11 @@ RUN apk add --no-cache \
     pip3 --no-cache-dir install -r requirements.pip && \
     rm -rf /var/cache/apk/* \
     rm -rf *
+
+ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
+ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./
+
+RUN sed -i '/.*linux_amd64.zip/!d' packer_${PACKER_VERSION}_SHA256SUMS
+RUN sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
+RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
+RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip


### PR DESCRIPTION
Used this as source https://github.com/hashicorp/docker-hub-images/blob/master/packer/Dockerfile-light