### PR TITLE
bump: Upgrade awscli and boto3 verions

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,7 @@
 requests-aws4auth==1.1.2
-botocore==1.18.5
-awscli==1.18.146
-boto3==1.15.5
+botocore==1.27.9
+awscli==1.25.9
+boto3==1.24.9
 ssm2eb==0.5.1
 PyYaml==5.3.1
 colorama==0.3.9


### PR DESCRIPTION
Following [this commit](https://github.com/codacy/ci-aws/commit/390aaccf8979ee14eb96eb5193a83db8fffe60de), it seems that some projects are having issues with dependencies.

I'm marking this as a bump and not breaking, because that linked commit above is already marked as such, and this is a follow up to that.